### PR TITLE
Correct spelling of "unistall" to "uninstall" on lines 254 and  582

### DIFF
--- a/phonesploit.py
+++ b/phonesploit.py
@@ -251,7 +251,7 @@ def main():
         print (("     "+connect))
         print (("    [{0}+{1}]Enter a package name.").format(Fore.RED, Fore.WHITE))
         package_name = input("    "+arrow + "phonesploit"+Fore.RED + "(app_delete) "+Fore.WHITE + "> ")
-        os.system("adb -s "+device_name+" unistall "+package_name)
+        os.system("adb -s "+device_name+" uninstall "+package_name)
 
     elif option == '12':
         print (("\n[{0}+{1}]Enter a device name.").format(Fore.RED, Fore.WHITE))
@@ -579,7 +579,7 @@ def main_linux():
             print (("     "+connect))
             print (("    [{0}+{1}]Enter a package name.").format(Fore.RED, Fore.WHITE))
             package_name = input("    "+arrow + "phonesploit"+Fore.RED + "(app_delete) "+Fore.WHITE + "> ")
-            os.system("adb -s "+device_name+" unistall "+package_name)
+            os.system("adb -s "+device_name+" uninstall "+package_name)
             option = input(Fore.WHITE + "phonesploit"+Fore.RED + "(main_menu) "+Fore.WHITE + "> ")
 
         elif option == '12':


### PR DESCRIPTION
Command for uninstalling an apk wasn't working due to the spelling mistake.

Have a good one!